### PR TITLE
Using single quotes instead of double quotes

### DIFF
--- a/src/main/java/org/drizzle/jdbc/internal/common/query/parameters/ByteParameter.java
+++ b/src/main/java/org/drizzle/jdbc/internal/common/query/parameters/ByteParameter.java
@@ -39,14 +39,14 @@ public class ByteParameter implements ParameterHolder {
     public ByteParameter(final byte[] x) {
         buffer = new byte[x.length * 2 + 2];
         int pos = 0;
-        buffer[pos++] = '"';
+        buffer[pos++] = '\'';
         for (final byte b : x) {
             if (needsEscaping(b)) {
                 buffer[pos++] = '\\';
             }
             buffer[pos++] = b;
         }
-        buffer[pos++] = '"';
+        buffer[pos++] = '\'';
         this.length = pos;
     }
 

--- a/src/main/java/org/drizzle/jdbc/internal/common/query/parameters/DateParameter.java
+++ b/src/main/java/org/drizzle/jdbc/internal/common/query/parameters/DateParameter.java
@@ -45,13 +45,13 @@ public class DateParameter implements ParameterHolder {
      */
     public DateParameter(final long timestamp) {
         final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-        byteRepresentation = String.valueOf("\"" + sdf.format(new Date(timestamp)) + "\"").getBytes();
+        byteRepresentation = String.valueOf("'" + sdf.format(new Date(timestamp)) + "'").getBytes();
     }
 
     public DateParameter(final long timestamp, final Calendar cal) {
         final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         sdf.setCalendar(cal);
-        byteRepresentation = String.valueOf("\"" + sdf.format(new Date(timestamp)) + "\"").getBytes();
+        byteRepresentation = String.valueOf("'" + sdf.format(new Date(timestamp)) + "'").getBytes();
 
     }
 

--- a/src/main/java/org/drizzle/jdbc/internal/common/query/parameters/TimeParameter.java
+++ b/src/main/java/org/drizzle/jdbc/internal/common/query/parameters/TimeParameter.java
@@ -38,7 +38,7 @@ public class TimeParameter implements ParameterHolder {
 
     public TimeParameter(final long timestamp) {
         SimpleDateFormat sdf = new SimpleDateFormat("HH:mm:ss");
-        byteRepresentation = ("\""+sdf.format(new Date(timestamp))+"\"").getBytes();
+        byteRepresentation = ("'"+sdf.format(new Date(timestamp))+"'").getBytes();
     }
 
     public int writeTo(final OutputStream os, int offset, int maxWriteSize) throws IOException {

--- a/src/main/java/org/drizzle/jdbc/internal/common/query/parameters/TimestampParameter.java
+++ b/src/main/java/org/drizzle/jdbc/internal/common/query/parameters/TimestampParameter.java
@@ -45,13 +45,13 @@ public class TimestampParameter implements ParameterHolder {
      */
     public TimestampParameter(final long timestamp) {
         final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
-        byteRepresentation = String.valueOf("\"" + sdf.format(new Date(timestamp)) + "\"").getBytes();
+        byteRepresentation = String.valueOf("'" + sdf.format(new Date(timestamp)) + "'").getBytes();
     }
 
     public TimestampParameter(final long timestamp, final Calendar cal) {
         final SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
         sdf.setCalendar(cal);
-        byteRepresentation = String.valueOf("\"" + sdf.format(new Date(timestamp)) + "\"").getBytes();
+        byteRepresentation = String.valueOf("'" + sdf.format(new Date(timestamp)) + "'").getBytes();
 
     }
 


### PR DESCRIPTION
This change prevents from getting errors when using prepared statements with MySQL running in ANSI mode.

http://dev.mysql.com/doc/refman/5.0/en/server-sql-mode.html#sqlmode_ansi_quotes

The following classes still make use of double quotes and might require the same kind of change :
- StreamParameter
- SerializableParameter
- ReaderParameter
- BlobStreamingParameter
- BufferedReaderParameter
- BufferedStreamParameter
