### PR TITLE
Fixed parsing of floating point values using getInt, getLong, getShort and getByte

### DIFF
--- a/src/main/java/org/drizzle/jdbc/internal/common/Utils.java
+++ b/src/main/java/org/drizzle/jdbc/internal/common/Utils.java
@@ -410,6 +410,13 @@ public class Utils {
     public static int byteArrayToInt(byte [] b) {
         int sum = 0;
         int len = b.length;
+        
+        for(int i = 0; i < b.length; i++) {
+        	if(b[i] == '.'){
+        		len = i;
+        		break;
+        	}
+        }
 
         int limit = -Integer.MAX_VALUE;
         int startIdx = 0;
@@ -430,9 +437,7 @@ public class Utils {
 
         }
         int factor = (int) Math.pow(10, len-1-startIdx);
-        for(int i = startIdx; i < b.length; i++) {
-        	if(b[i] == '.')
-        		break;
+        for(int i = startIdx; i < len; i++) {
             byte x = (byte) (b[i] - '0');
             if(x < 0 || x > 9) throw new NumberFormatException("Could not parse as int");
             int oldSum = sum;
@@ -450,6 +455,13 @@ public class Utils {
     public static long byteArrayToLong(byte [] b) {
         long sum = 0;
         int len = b.length;
+        
+        for(int i = 0; i < b.length; i++) {
+        	if(b[i] == '.'){
+        		len = i;
+        		break;
+        	}
+        }
 
         long limit = -Long.MAX_VALUE;
         int startIdx = 0;
@@ -470,9 +482,7 @@ public class Utils {
 
         }
         long factor = (long) Math.pow(10, len-1-startIdx);
-        for(int i = startIdx; i < b.length; i++) {
-        	if(b[i] == '.')
-        		break;
+        for(int i = startIdx; i < len; i++) {
             byte x = (byte) (b[i] - '0');
             if(x < 0 || x > 9) throw new NumberFormatException("Could not parse as long");
             long oldSum = sum;


### PR DESCRIPTION
Most JDBC drivers would not complain if getInt, getLong, getShort or getByte was called on a floating point value and would simply truncate the floating value instead (e.g. "1.9" would become "1", "-1.9" would become "-1").
