### PR TITLE
Copy query parameters in a parameterized query

### DIFF
--- a/src/main/java/org/drizzle/jdbc/internal/common/query/DrizzleParameterizedQuery.java
+++ b/src/main/java/org/drizzle/jdbc/internal/common/query/DrizzleParameterizedQuery.java
@@ -32,6 +32,7 @@ import org.drizzle.jdbc.internal.common.query.parameters.ParameterHolder;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -63,7 +64,7 @@ public class DrizzleParameterizedQuery implements ParameterizedQuery {
         this.query = paramQuery.getQuery();
         this.queryPartsArray = paramQuery.getQueryPartsArray();
         paramCount = queryPartsArray.length - 1;
-        parameters = new ParameterHolder[paramCount];
+        parameters = Arrays.copyOf(paramQuery.getParameters(), paramCount);
     }
 
     public void setParameter(final int position, final ParameterHolder parameter) throws IllegalParameterException {

--- a/src/test/java/org/drizzle/jdbc/DriverTest.java
+++ b/src/test/java/org/drizzle/jdbc/DriverTest.java
@@ -437,6 +437,13 @@ public class DriverTest {
         assertEquals(true,rs.next());
         assertEquals("ccc",rs.getString(2));
 
+        // test reuse of batch parameters between addBatch calls
+        ps.setString(1, "ddd");
+        ps.addBatch();
+        ps.addBatch();
+        a = ps.executeBatch();
+        assertEquals(2, a.length);
+        for(int c : a) assertEquals(1, c);
     }
     @Test
     public void batchTestStmt() throws SQLException {


### PR DESCRIPTION
This allows batched statements to reuse parameters.
