### PR TITLE
 Fixes issue #32 : if connection is already closed, do nothing

### DIFF
--- a/src/main/java/org/drizzle/jdbc/DrizzleConnection.java
+++ b/src/main/java/org/drizzle/jdbc/DrizzleConnection.java
@@ -226,6 +226,8 @@ public final class DrizzleConnection
      * @throws SQLException if there is a problem talking to the server.
      */
     public void close() throws SQLException {
+        if (isClosed())
+            return;
         try {
             this.timeoutExecutor.shutdown();
             protocol.close();


### PR DESCRIPTION
Fixed issue #32 by checking connection is already closed.
If so, just return.
