### PR TITLE
Removing useless double instantiation

### DIFF
--- a/src/main/java/org/drizzle/jdbc/internal/common/query/DrizzleQueryFactory.java
+++ b/src/main/java/org/drizzle/jdbc/internal/common/query/DrizzleQueryFactory.java
@@ -42,7 +42,7 @@ public class DrizzleQueryFactory implements QueryFactory {
     public ParameterizedQuery createParameterizedQuery(final String query, boolean noCache) {
 
         if(noCache)
-            return new DrizzleParameterizedQuery(new DrizzleParameterizedQuery(query));
+            return new DrizzleParameterizedQuery(query);
 
         // Cache prepared statements
         ParameterizedQuery pq = DrizzleQueryFactory.PREPARED_CACHE.get(query);


### PR DESCRIPTION
There was a useless double DrizzleParameterizedQuery instantiation :
new DrizzleParameterizedQuery(new DrizzleParameterizedQuery(query))

Replacing it with :
new DrizzleParameterizedQuery(query)